### PR TITLE
Support for Windows back-slash paths

### DIFF
--- a/lib/eh/commands/repository.rb
+++ b/lib/eh/commands/repository.rb
@@ -51,7 +51,7 @@ command :repository do |command|
 
       Eh::Settings.current.data['repositories'] << {
         'url' => args[0],
-        'dir' => args[1],
+        'dir' => File::ALT_SEPARATOR ? args[1].gsub(File::ALT_SEPARATOR, File::SEPARATOR) : args[1],
         'deploy_username' => args[2],
         'deploy_password' => args[3],
         'current' => (Eh::Settings.current.data['repositories'].length == 0)


### PR DESCRIPTION
Now you can add repos with Windows style-paths copied from `explorer.exe`
`eh repository add https://example.repo/svn/project C:\Users\sampleUser\Doc
uments\eventhub user@example.com passw0rd`
I check if `File::ALT_SEPARATOR` is not `nil` in order to make sure it can't be used in dir name (on linux backslash can be a part of directory name).